### PR TITLE
Fix Release Team Selection Link

### DIFF
--- a/release-team/role-handbooks/enhancements/README.md
+++ b/release-team/role-handbooks/enhancements/README.md
@@ -286,7 +286,7 @@ https://groups.google.com/forum/#!topic/kubernetes-dev/5qU8irU7_tE
 [enhancements-issues]: https://github.com/kubernetes/enhancements/issues
 [k/enhancements]: https://github.com/kubernetes/enhancements
 [rt-group]: https://groups.google.com/a/kubernetes.io/g/release-team
-[rt-selection]: /README.md#release-team-selection
+[rt-selection]: /release-team/release-team-selection.md
 [rt-requirements]: /release-team/release-team-onboarding.md
 [sig-arch-readme]: https://github.com/kubernetes/community/tree/master/sig-architecture/README.md
 [sig-arch-group]: https://groups.google.com/forum/#!forum/kubernetes-sig-architecture


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this:
/kind cleanup

#### What this PR does / why we need it:
The PR fixes broken link to [release team selection](https://github.com/kubernetes/sig-release/blob/master/release-team/release-team-selection.md ) document, in the Enhancements Role handbook.
